### PR TITLE
Fix for logic error in use of forEach

### DIFF
--- a/classes/util.js
+++ b/classes/util.js
@@ -47,17 +47,17 @@ class Util {
   }
 
   objectsHaveAllProps(objs, props) {
-    objs.forEach((obj) => {
+    for (let obj of objs) {
       if (!this.objectHasAllProps(obj, props)) return false;
-    });
+    }
 
     return true;
   }
 
   objectHasAllProps(obj, props) {
-    props.forEach((prop) => {
+    for (let prop of props) {
       if (!obj.hasOwnProperty(prop)) return false;
-    });
+    }
 
     return true;
   }


### PR DESCRIPTION
Found this repo from your write-up on dev.to. All in all, this is some great work!

An important thing to remember (that has bitten me in the past more than once, unfortunately) is that when calling the `forEach` method on an array, you're passing in a function to be called with each array element. As such, a `return` statement in that callback function only returns from the callback function, rather than returning from the function in which the `forEach` call is made (which I assume is the intended behavior). Because of this, both `objectHasAllProps` and `objectsHaveAllProps` in the util.js file will always return true in the end. This PR changes both uses of `forEach` to regular for loops, since returning out of a for loop will return out of the intended function.